### PR TITLE
Use official OpenAI ChatGPT API

### DIFF
--- a/chatgpt_airsim/README.md
+++ b/chatgpt_airsim/README.md
@@ -7,7 +7,7 @@ These scripts allow users to interact with and command a drone inside a [Microso
 For details on how to use AirSim and its original API, please visit the [AirSim documentation](https://microsoft.github.io/AirSim/).
 
 ## Getting started (Windows only - for now)
-- As a prerequisite, you need to create an OpenAI account the allows access ChatGPT through the chat.openai.com website.
+- As a prerequisite, you need to create an OpenAI account the allows access ChatGPT through the OpenAI API. You can do so by visiting https://platform.openai.com and signing up for an account.
 - Set up the conda environment  
 ```
 conda env create -f environment.yml
@@ -17,7 +17,7 @@ conda env create -f environment.yml
 conda activate chatgpt
 pip install airsim
 ```
-- Set up the access token such that the ChatGPT interface can communicate with the model. Make sure you are logged in to the ChatGPT website. Then, navigate to https://chat.openai.com/api/auth/session, and copy the `accessToken`. Paste it in the `access_token` field of `config.json`. 
+- Set up an API key by visiting https://platform.openai.com/account/api-keys. Copy the API key and paste it in the `OPENAI_API_KEY` field of `config.json`.
 - Download the AirSim zip file from [Releases](https://github.com/microsoft/PromptCraft-Robotics/releases), and unzip the package.
 - Copy `settings.json` to `C:\Users\<username>\Documents\AirSim\`.
   
@@ -29,4 +29,4 @@ The interface shows an `AirSim>` prompt when it is ready to take user questions/
 
 We emphasize that this is meant to be a sample environment and interface aimed at getting started with ChatGPT and robotics applications inside a simulation sandbox. ChatGPT generated code could result in unexpected behavior or crashes, especially as the interface is written in a way that it executes the commands directly. That said, we do encourage users to test out the capabilities of the model, and to contribute new prompting techniques, additional wrapper functions, or any other enhancements to this interface.
 
-Additionally, methods of accessing the ChatGPT service (such as the revchatGPT package used in this interface) could change over time. We encourage users to keep evaluating new methods including official API access or the Azure OpenAI service as appropriate.
+We encourage users to keep evaluating new methods of accessing the ChatGPT service such as the Azure OpenAI service as appropriate.

--- a/chatgpt_airsim/chatgpt_airsim.py
+++ b/chatgpt_airsim/chatgpt_airsim.py
@@ -26,6 +26,18 @@ chat_history = [
     {
         "role": "system",
         "content": sysprompt
+    },
+    {
+        "role": "user",
+        "content": "move 10 units up"
+    },
+    {
+        "role": "assistant",
+        "content": """```python
+aw.fly_to([aw.get_drone_position()[0], aw.get_drone_position()[1], aw.get_drone_position()[2]+10])
+```
+
+This code uses the `fly_to()` function to move the drone to a new position that is 10 units up from the current position. It does this by getting the current position of the drone using `get_drone_position()` and then creating a new list with the same X and Y coordinates, but with the Z coordinate increased by 10. The drone will then fly to this new position using `fly_to()`."""
     }
 ]
 

--- a/chatgpt_airsim/chatgpt_airsim.py
+++ b/chatgpt_airsim/chatgpt_airsim.py
@@ -10,6 +10,7 @@ import time
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--prompt", type=str, default="prompts/airsim_basic.txt")
+parser.add_argument("--sysprompt", type=str, default="system_prompts/airsim_basic.txt")
 args = parser.parse_args()
 
 with open("config.json", "r") as f:
@@ -18,12 +19,13 @@ with open("config.json", "r") as f:
 print("Initializing ChatGPT...")
 openai.api_key = config["OPENAI_API_KEY"]
 
+with open(args.sysprompt, "r") as f:
+    sysprompt = f.read()
+
 chat_history = [
     {
         "role": "system",
-        "content": """You are an assistant helping me with the AirSim simulator for drones. When I ask you to do something, you are supposed to give me Python code 
-                    that is needed to achieve that task using AirSim and then an explanation of what that code does. You are only allowed to use the functions I have
-                    defined for you. You are not to use any other hypothetical functions that you think might exist. You can use simple Python functions from libraries such as math and numpy.""",
+        "content": sysprompt
     }
 ]
 

--- a/chatgpt_airsim/chatgpt_airsim.py
+++ b/chatgpt_airsim/chatgpt_airsim.py
@@ -18,24 +18,33 @@ with open("config.json", "r") as f:
 print("Initializing ChatGPT...")
 openai.api_key = config["OPENAI_API_KEY"]
 
-chat_history = [{
-    "role": "system",
-    "content": "You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible.",
-}]
+chat_history = [
+    {
+        "role": "system",
+        "content": """You are an assistant helping me with the AirSim simulator for drones. When I ask you to do something, you are supposed to give me Python code 
+                    that is needed to achieve that task using AirSim and then an explanation of what that code does. You are only allowed to use the functions I have
+                    defined for you. You are not to use any other hypothetical functions that you think might exist. You can use simple Python functions from libraries such as math and numpy.""",
+    }
+]
+
 
 def ask(prompt):
-    chat_history.append({
-        "role": "user",
-        "content": prompt,
-    })
+    chat_history.append(
+        {
+            "role": "user",
+            "content": prompt,
+        }
+    )
     completion = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=chat_history,
     )
-    chat_history.append({
-        "role": "assistant",
-        "content": completion.choices[0].message.content,
-    })
+    chat_history.append(
+        {
+            "role": "assistant",
+            "content": completion.choices[0].message.content,
+        }
+    )
     return chat_history[-1]["content"]
 
 

--- a/chatgpt_airsim/chatgpt_airsim.py
+++ b/chatgpt_airsim/chatgpt_airsim.py
@@ -40,6 +40,7 @@ def ask(prompt):
     completion = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=chat_history,
+        temperature=0
     )
     chat_history.append(
         {

--- a/chatgpt_airsim/chatgpt_airsim.py
+++ b/chatgpt_airsim/chatgpt_airsim.py
@@ -1,4 +1,4 @@
-from revChatGPT.V1 import Chatbot
+import openai
 import re
 import argparse
 from airsim_wrapper import *
@@ -16,14 +16,27 @@ with open("config.json", "r") as f:
     config = json.load(f)
 
 print("Initializing ChatGPT...")
-chatgpt = Chatbot(config=config)
+openai.api_key = config["OPENAI_API_KEY"]
 
+chat_history = [{
+    "role": "system",
+    "content": "You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible.",
+}]
 
 def ask(prompt):
-    for data in chatgpt.ask(prompt):
-        response = data["message"]
-
-    return response
+    chat_history.append({
+        "role": "user",
+        "content": prompt,
+    })
+    completion = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=chat_history,
+    )
+    chat_history.append({
+        "role": "assistant",
+        "content": completion.choices[0].message.content,
+    })
+    return chat_history[-1]["content"]
 
 
 print(f"Done.")

--- a/chatgpt_airsim/config.json
+++ b/chatgpt_airsim/config.json
@@ -1,3 +1,3 @@
 {
-    "access_token": "token goes here"
+    "OPENAI_API_KEY": "api key goes here"
 }

--- a/chatgpt_airsim/environment.yml
+++ b/chatgpt_airsim/environment.yml
@@ -11,9 +11,8 @@ dependencies:
     - msgpack-python==0.5.6
     - msgpack-rpc-python==0.4.1
     - numpy==1.24.2
-    - OpenAIAuth==0.3.2
     - opencv-contrib-python==4.7.0.68
     - requests==2.28.2
-    - revChatGPT==2.3.4
+    - openai==0.27.0
     - tornado==4.5.3
     - urllib3==1.26.14

--- a/chatgpt_airsim/environment.yml
+++ b/chatgpt_airsim/environment.yml
@@ -13,6 +13,6 @@ dependencies:
     - numpy==1.24.2
     - opencv-contrib-python==4.7.0.68
     - requests==2.28.2
-    - openai==0.27.0
+    - openai==0.27.2
     - tornado==4.5.3
     - urllib3==1.26.14

--- a/chatgpt_airsim/prompts/airsim_basic.txt
+++ b/chatgpt_airsim/prompts/airsim_basic.txt
@@ -9,6 +9,17 @@ aw.set_yaw(yaw) - sets the yaw of the drone to the specified value in degrees.
 aw.get_yaw() - returns the current yaw of the drone in degrees.
 aw.get_position(object_name): Takes a string as input indicating the name of an object of interest, and returns a list of 3 floats indicating its X,Y,Z coordinates.
 
+The following is an example of how you would respond:
+
+"""
+Me: move 10 units up
+You: ```python
+aw.fly_to([aw.get_drone_position()[0], aw.get_drone_position()[1], aw.get_drone_position()[2]+10])
+```
+
+This code uses the `fly_to()` function to move the drone to a new position that is 10 units up from the current position. It does this by getting the current position of the drone using `get_drone_position()` and then creating a new list with the same X and Y coordinates, but with the Z coordinate increased by 10. The drone will then fly to this new position using `fly_to()`.
+"""
+
 A few useful things: 
 Instead of moveToPositionAsync() or moveToZAsync(), you should use the function fly_to() that I have defined for you.
 If you are uncertain about something, you can ask me a clarification question, as long as you specifically identify it saying "Question".

--- a/chatgpt_airsim/prompts/airsim_basic.txt
+++ b/chatgpt_airsim/prompts/airsim_basic.txt
@@ -9,17 +9,6 @@ aw.set_yaw(yaw) - sets the yaw of the drone to the specified value in degrees.
 aw.get_yaw() - returns the current yaw of the drone in degrees.
 aw.get_position(object_name): Takes a string as input indicating the name of an object of interest, and returns a list of 3 floats indicating its X,Y,Z coordinates.
 
-The following is an example of how you would respond:
-
-"""
-Me: move 10 units up
-You: ```python
-aw.fly_to([aw.get_drone_position()[0], aw.get_drone_position()[1], aw.get_drone_position()[2]+10])
-```
-
-This code uses the `fly_to()` function to move the drone to a new position that is 10 units up from the current position. It does this by getting the current position of the drone using `get_drone_position()` and then creating a new list with the same X and Y coordinates, but with the Z coordinate increased by 10. The drone will then fly to this new position using `fly_to()`.
-"""
-
 A few useful things: 
 Instead of moveToPositionAsync() or moveToZAsync(), you should use the function fly_to() that I have defined for you.
 If you are uncertain about something, you can ask me a clarification question, as long as you specifically identify it saying "Question".
@@ -37,5 +26,3 @@ None of the objects except for the drone itself are movable. Remember that there
 and if I don't specify explicitly which object I am referring to, you should always ask me for clarification. Never make assumptions.
 
 In terms of axis conventions, forward means positive X axis. Right means positive Y axis. Up means positive Z axis.
-
-Are you ready?

--- a/chatgpt_airsim/prompts/airsim_basic.txt
+++ b/chatgpt_airsim/prompts/airsim_basic.txt
@@ -1,6 +1,4 @@
-I would like you to help me work with the AirSim simulator for drones. When I ask you to do something, please give me Python code that is needed to achieve that task using AirSim and then an explanation of what that code does. 
-Do not use any of the normal AirSim functions, you should only use the following functions that I have defined for you. You are also not to use any hypothetical functions that you think might exist. You should only use the functions that I have defined for you.
-You can use simple Python functions from libraries such as math and numpy.
+Here are some functions you can use to command the drone.
 
 aw.takeoff() - takes off the drone.
 aw.land() - lands the drone.

--- a/chatgpt_airsim/system_prompts/airsim_basic.txt
+++ b/chatgpt_airsim/system_prompts/airsim_basic.txt
@@ -1,0 +1,5 @@
+You are an assistant helping me with the AirSim simulator for drones.
+When I ask you to do something, you are supposed to give me Python code that is needed to achieve that task using AirSim and then an explanation of what that code does.
+You are only allowed to use the functions I have defined for you.
+You are not to use any other hypothetical functions that you think might exist.
+You can use simple Python functions from libraries such as math and numpy.


### PR DESCRIPTION
Instead of relying on an unofficial method to access ChatGPT, this PR uses the official API to avoid potential issues or errors that might arise from using an unsupported approach.

However, this also introduces a new challenge: setting a system message. This issue was not addressed in the original paper, so I decided to use one of the system prompts that were used in ChatGPT as a baseline.